### PR TITLE
feat: add User.lastLoginAt for accurate RGPD retention, richer SEO/AE…

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -272,6 +272,7 @@ exports.login = async (req, res) => {
   const refreshToken = generateRefreshToken(user);
   await prisma.refreshToken.deleteMany({ where: { userId: user.id } });
   await prisma.refreshToken.create({ data: { token: refreshToken, userId: user.id, expiresAt: new Date(Date.now() + REFRESH_TOKEN_TTL_MS) } });
+  await prisma.user.update({ where: { id: user.id }, data: { lastLoginAt: new Date() } });
   res.cookie('accessToken', accessToken, Object.assign({ maxAge: ACCESS_TOKEN_TTL_MS }, cookieOptions()));
   res.cookie('refreshToken', refreshToken, Object.assign({ maxAge: REFRESH_TOKEN_TTL_MS }, cookieOptions()));
   res.json({ id: user.id, email: user.email, name: user.name, role: user.role, centerId: user.centerId || null });

--- a/backend/lib/dataRetentionCron.js
+++ b/backend/lib/dataRetentionCron.js
@@ -91,7 +91,9 @@ async function purgeOldPushSubscriptions() {
 
 /**
  * Anonymize inactive users (no login for 2 years).
- * We cannot determine last login from the schema, so we use updatedAt on the User record.
+ * lastLoginAt is set on every login (password + OAuth); accounts created before this field
+ * existed have lastLoginAt = null, so we also require updatedAt to be old to avoid
+ * anonymizing an account that logged in recently but whose lastLoginAt backfill is missing.
  * The name and email are replaced with anonymized placeholders; the account is kept for
  * audit trail purposes (e.g. payment history foreign keys).
  */
@@ -101,6 +103,7 @@ async function anonymizeInactiveUsers() {
   const inactive = await prisma.user.findMany({
     where: {
       updatedAt: { lt: cutoff },
+      OR: [{ lastLoginAt: null }, { lastLoginAt: { lt: cutoff } }],
       // Exclude super-admins
       NOT: { role: { in: ['super-admin', 'super_admin', 'SUPER_ADMIN'] } },
       // Skip already-anonymized accounts

--- a/backend/prisma/migrations/20260805194058_add_user_last_login_at/migration.sql
+++ b/backend/prisma/migrations/20260805194058_add_user_last_login_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."User" ADD COLUMN     "lastLoginAt" TIMESTAMP(3);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -96,6 +96,7 @@ model User {
   supportTickets           SupportTicket[]
   createdAt                DateTime                  @default(now())
   updatedAt                DateTime                  @updatedAt
+  lastLoginAt              DateTime?
   feedPosts                FeedPost[]
   feedLikes                FeedLike[]
   feedComments             FeedComment[]
@@ -233,25 +234,25 @@ model Report {
 }
 
 model Center {
-  id                      String          @id @default(uuid())
-  name                    String
-  users                   User[]
-  parents                 Parent[]
-  children                Child[]
-  nannies                 Nanny[]
-  assignments             Assignment[]
-  schedules               Schedule[]
-  reports                 Report[]
-  feedPosts               FeedPost[]
-  reviews                 Review[]
-  presenceSheets          PresenceSheet[]
-  conversations           Conversation[]
-  createdAt               DateTime        @default(now())
-  notifyByEmail           Boolean         @default(true)
-  dailyRate               Float           @default(2.0)
-  childCotisationAmount   Float           @default(15.0)
-  nannyCotisationAmount   Float           @default(10.0)
-  showInDirectory         Boolean         @default(true)
+  id                    String          @id @default(uuid())
+  name                  String
+  users                 User[]
+  parents               Parent[]
+  children              Child[]
+  nannies               Nanny[]
+  assignments           Assignment[]
+  schedules             Schedule[]
+  reports               Report[]
+  feedPosts             FeedPost[]
+  reviews               Review[]
+  presenceSheets        PresenceSheet[]
+  conversations         Conversation[]
+  createdAt             DateTime        @default(now())
+  notifyByEmail         Boolean         @default(true)
+  dailyRate             Float           @default(2.0)
+  childCotisationAmount Float           @default(15.0)
+  nannyCotisationAmount Float           @default(10.0)
+  showInDirectory       Boolean         @default(true)
 }
 
 model Subscription {
@@ -591,13 +592,13 @@ model AnnouncementRead {
 
 // Logs des pages 404 — accessible uniquement par le super-admin
 model NotFoundLog {
-  id          String   @id @default(uuid())
+  id          String    @id @default(uuid())
   url         String
-  count       Int      @default(1)
+  count       Int       @default(1)
   userAgent   String?
-  firstSeenAt DateTime @default(now())
-  lastSeenAt  DateTime @default(now())
-  resolved    Boolean  @default(false)
+  firstSeenAt DateTime  @default(now())
+  lastSeenAt  DateTime  @default(now())
+  resolved    Boolean   @default(false)
   resolvedAt  DateTime?
 
   @@index([lastSeenAt])

--- a/backend/routes/oauth.js
+++ b/backend/routes/oauth.js
@@ -42,6 +42,7 @@ async function loginAndRedirect(res, user, isNew) {
   await prisma.refreshToken.create({
     data: { token: refreshToken, userId: user.id, expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000) },
   });
+  await prisma.user.update({ where: { id: user.id }, data: { lastLoginAt: new Date() } });
 
   res.cookie('accessToken', accessToken, Object.assign({ maxAge: 15 * 60 * 1000 }, cookieOptions()));
   res.cookie('refreshToken', refreshToken, Object.assign({ maxAge: 7 * 24 * 60 * 60 * 1000 }, cookieOptions()));
@@ -62,6 +63,7 @@ async function loginAndRespond(res, user, isNew) {
   await prisma.refreshToken.create({
     data: { token: refreshToken, userId: user.id, expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000) },
   });
+  await prisma.user.update({ where: { id: user.id }, data: { lastLoginAt: new Date() } });
 
   res.cookie('accessToken', accessToken, Object.assign({ maxAge: 15 * 60 * 1000 }, cookieOptions()));
   res.cookie('refreshToken', refreshToken, Object.assign({ maxAge: 7 * 24 * 60 * 60 * 1000 }, cookieOptions()));

--- a/components/buildJsonLd.ts
+++ b/components/buildJsonLd.ts
@@ -135,3 +135,16 @@ export function buildJsonLd(props: Partial<SEOProps> & { url?: string }): JsonLd
 
   return [...jsonLD, ...extraLd];
 }
+
+/** Build a FAQPage JSON-LD object from a simple {q, a}[] list, e.g. an on-page FAQ accordion. */
+export function buildFaqLd(items: { q: string; a: string }[]): JsonLdObject {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: items.map(({ q, a }) => ({
+      '@type': 'Question',
+      name: q,
+      acceptedAnswer: { '@type': 'Answer', text: a },
+    })),
+  };
+}

--- a/pages/GuideAddChildPage.tsx
+++ b/pages/GuideAddChildPage.tsx
@@ -1,18 +1,66 @@
 import SEO from '../components/SEO';
+import { buildFaqLd } from '../components/buildJsonLd';
 import PublicNavbar from '../components/PublicNavbar';
 import PublicFooter from '../components/PublicFooter';
 import { Link } from 'react-router-dom';
+
+const STEPS = [
+  {
+    title: 'Ouvrir le formulaire d\'ajout',
+    desc: 'Depuis le menu principal, accédez à la rubrique "Enfants" puis cliquez sur le bouton "Ajouter" en haut de la liste.',
+  },
+  {
+    title: 'Renseigner l\'identité de l\'enfant',
+    desc: "Saisissez le nom, la date de naissance et le sexe. Le groupe d'âge (0-1 an, 1-2 ans, 2-3 ans...) est calculé automatiquement à partir de la date de naissance, mais reste modifiable si besoin.",
+  },
+  {
+    title: 'Lier un ou plusieurs parents',
+    desc: "Recherchez un parent déjà existant par email, ou créez une nouvelle fiche parent directement depuis ce formulaire (nom, téléphone, email). L'enfant peut être lié à plusieurs parents ou responsables légaux.",
+  },
+  {
+    title: 'Renseigner les informations médicales',
+    desc: "Ajoutez les allergies connues et toute information médicale utile à l'équipe (traitement, ordonnance). Ces informations sont visibles uniquement par l'équipe encadrante et les parents liés à l'enfant.",
+  },
+  {
+    title: 'Ajouter une photo (avec consentement)',
+    desc: "Une photo peut être ajoutée à la fiche enfant. Le consentement photographique des parents est demandé séparément et conditionne l'apparition de l'enfant dans le fil d'actualité partagé.",
+  },
+  {
+    title: 'Assigner l\'enfant à une nounou',
+    desc: "Une fois la fiche créée, affectez l'enfant à un ou plusieurs intervenants depuis le planning. Cette affectation détermine qui peut consulter et modifier ses données au quotidien.",
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    q: 'Quelles informations sont obligatoires pour créer une fiche enfant ?',
+    a: 'Le nom, la date de naissance et le sexe sont obligatoires. Le groupe est calculé automatiquement mais peut être ajusté. Les allergies, informations médicales et photo sont facultatives mais recommandées.',
+  },
+  {
+    q: 'Qui peut voir les informations médicales et les allergies ?',
+    a: "Seuls l'équipe encadrante de la structure (nounous assignées, administrateurs) et les parents liés à l'enfant peuvent consulter ces informations. Elles ne sont jamais visibles par d'autres familles.",
+  },
+  {
+    q: "Peut-on lier un enfant à deux parents séparés ?",
+    a: "Oui, une fiche enfant peut être liée à plusieurs comptes parents (par exemple en cas de garde partagée). Chaque parent lié accède au planning, aux rapports et au fil d'actualité de son enfant.",
+  },
+  {
+    q: 'Comment modifier ou supprimer une fiche enfant existante ?',
+    a: "Depuis la liste \"Enfants\", utilisez les boutons d'action sur la ligne de l'enfant concerné pour modifier ses informations ou supprimer sa fiche. La suppression retire aussi ses liens de planning et de facturation.",
+  },
+];
 
 export default function GuideAddChildPage() {
   return (
     <div className="min-h-screen w-full flex flex-col overflow-x-hidden bg-white">
       <SEO
-        title={"Ajouter un enfant dans le logiciel | Guide Frimousse - Gestion creche"}
-        description={"Comment ajouter un enfant dans Frimousse : formulaire d'inscription, informations medicales, contacts d'urgence, autorisations parentales. Guide pour creches et MAM."}
+        title={"Ajouter un enfant dans le logiciel | Guide Frimousse - Gestion crèche"}
+        description={"Comment ajouter un enfant dans Frimousse : identité, groupe d'âge, liaison aux parents, informations médicales, allergies et consentement photo. Guide pour crèches, micro-crèches et MAM."}
         url={"https://lesfrimousses.com/guide-ajouter-enfant"}
         image={"https://lesfrimousses.com/imgs/og-banner.png"}
         type={"article"}
         breadcrumbs={[{ name: 'Accueil', url: 'https://lesfrimousses.com/' }, { name: 'Guide ajout enfant', url: 'https://lesfrimousses.com/guide-ajouter-enfant' }]}
+        ldJson={buildFaqLd(FAQ_ITEMS)}
       />
       <PublicNavbar />
       <main className="flex-1 w-full">
@@ -27,35 +75,61 @@ export default function GuideAddChildPage() {
               Ajouter un enfant
             </h1>
             <p className="text-lg md:text-xl !text-[#ffffff] max-w-2xl mx-auto leading-relaxed">
-              Tutoriel pour ajouter un enfant dans Frimousse : formulaire, champs obligatoires, gestion des groupes et informations parentales.
+              Identité, groupe d'âge, liaison aux parents, informations médicales : le guide complet pour créer une fiche enfant.
             </p>
           </div>
           <div className="absolute bottom-0 left-0 right-0">
             <svg viewBox="0 0 1440 120" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full h-auto block"><path d="M0 120V60C240 15 480 0 720 25C960 50 1200 80 1440 50V120H0Z" fill="white"/></svg>
           </div>
         </section>
-        {/* ── Guide Card ── */}
-        <section className="py-20 md:py-24 px-6">
+
+        {/* ── Étapes ── */}
+        <section className="py-20 md:py-24 px-6 bg-white">
           <div className="max-w-3xl mx-auto">
-            <div className="bg-white rounded-3xl border border-gray-100 shadow-xl p-8">
-              <h2 className="text-2xl font-bold text-brand-700 mb-6 text-center">Ajouter un enfant</h2>
-              <ol className="list-decimal list-inside text-gray-700 space-y-3 mb-6 text-left">
-                <li>Accédez à la rubrique "Enfants" via le menu principal.</li>
-                <li>Cliquez sur le bouton "Ajouter" ou "+" en haut de la liste.</li>
-                <li>Remplissez le formulaire : nom, prénom, âge, sexe, contacts parentaux, allergies, groupe, etc.</li>
-                <li>Vérifiez les informations puis validez. L’enfant apparaît alors dans la liste.</li>
-                <li>Pour modifier ou supprimer un enfant, utilisez les boutons d’action à droite de chaque ligne.</li>
-              </ol>
-              <div className="mt-8 text-gray-500 text-sm">Astuce : Utilisez les groupes pour organiser les enfants par tranche d'âge.</div>
-              <div className="mt-10 flex flex-col sm:flex-row gap-4 justify-center items-center">
-                <Link to="/" className="group bg-white text-brand-700 px-8 py-4 rounded-2xl font-bold text-lg shadow-xl shadow-black/10 hover:shadow-2xl transition-all hover:-translate-y-0.5 inline-flex items-center gap-3">
-                  Retour à l'accueil
-                  <svg className="w-5 h-5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"/></svg>
-                </Link>
-                <Link to="/support" className="!text-[#ffffff] border-2 border-brand-500 hover:border-brand-600 px-8 py-4 rounded-2xl font-bold text-lg transition-all bg-brand-500 hover:bg-brand-600">
-                  Besoin d'aide ?
-                </Link>
-              </div>
+            <div className="text-center mb-12">
+              <span className="inline-block text-xs font-bold uppercase tracking-widest text-brand-500 bg-brand-50 px-4 py-1.5 rounded-full mb-4">Étape par étape</span>
+              <h2 className="text-3xl md:text-4xl font-extrabold text-gray-900 tracking-tight">Créer une fiche enfant</h2>
+            </div>
+            <ol className="space-y-6">
+              {STEPS.map((s, i) => (
+                <li key={i} className="flex gap-5 bg-gray-50 rounded-3xl border border-gray-100 p-6 md:p-8">
+                  <div className="flex-shrink-0 w-10 h-10 rounded-2xl bg-brand-500 text-white font-bold flex items-center justify-center">{i + 1}</div>
+                  <div>
+                    <h3 className="text-lg font-bold text-gray-900 mb-2">{s.title}</h3>
+                    <p className="text-gray-600 leading-relaxed">{s.desc}</p>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </section>
+
+        {/* ── FAQ ── */}
+        <section className="py-20 px-6 bg-gray-50">
+          <div className="max-w-3xl mx-auto">
+            <div className="text-center mb-12">
+              <span className="inline-block text-xs font-bold uppercase tracking-widest text-brand-500 bg-brand-50 px-4 py-1.5 rounded-full mb-4">FAQ</span>
+              <h2 className="text-3xl md:text-4xl font-extrabold text-gray-900 tracking-tight">Questions fréquentes sur les fiches enfants</h2>
+            </div>
+            <div className="space-y-4">
+              {FAQ_ITEMS.map((item, i) => (
+                <details key={i} className="group bg-white rounded-2xl border border-gray-100 overflow-hidden">
+                  <summary className="flex items-center justify-between p-6 cursor-pointer font-semibold text-gray-900 list-none">
+                    {item.q}
+                    <svg className="w-5 h-5 text-brand-500 flex-shrink-0 ml-4 transition-transform group-open:rotate-180" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" /></svg>
+                  </summary>
+                  <div className="px-6 pb-6 text-gray-600 leading-relaxed">{item.a}</div>
+                </details>
+              ))}
+            </div>
+            <div className="mt-10 flex flex-col sm:flex-row gap-4 justify-center items-center">
+              <Link to="/" className="group bg-white text-brand-700 px-8 py-4 rounded-2xl font-bold text-lg shadow-xl shadow-black/10 hover:shadow-2xl transition-all hover:-translate-y-0.5 inline-flex items-center gap-3 border border-gray-100">
+                Retour à l'accueil
+                <svg className="w-5 h-5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"/></svg>
+              </Link>
+              <Link to="/support" className="!text-[#ffffff] border-2 border-brand-500 hover:border-brand-600 px-8 py-4 rounded-2xl font-bold text-lg transition-all bg-brand-500 hover:bg-brand-600">
+                Besoin d'aide ?
+              </Link>
             </div>
           </div>
         </section>

--- a/pages/GuideExportReportPage.tsx
+++ b/pages/GuideExportReportPage.tsx
@@ -1,18 +1,62 @@
 import SEO from '../components/SEO';
+import { buildFaqLd } from '../components/buildJsonLd';
 import PublicNavbar from '../components/PublicNavbar';
 import PublicFooter from '../components/PublicFooter';
 import { Link } from 'react-router-dom';
+
+const STEPS = [
+  {
+    title: 'Accéder aux rapports',
+    desc: 'Depuis le menu principal, ouvrez la rubrique "Rapports". La liste affiche tous les rapports d\'activité de votre structure (ou uniquement ceux de vos enfants assignés pour une nounou).',
+  },
+  {
+    title: "Filtrer par type ou période",
+    desc: "Filtrez par type de rapport (incident, comportement, soin) ou sur les 30 derniers jours pour retrouver rapidement l'information recherchée.",
+  },
+  {
+    title: 'Consulter un rapport en détail',
+    desc: "Cliquez sur un rapport pour voir son contenu complet : priorité, description, enfant concerné, intervenant à l'origine du rapport et date.",
+  },
+  {
+    title: 'Suivre la facturation associée',
+    desc: "Les rapports d'activité et les présences alimentent automatiquement la facturation mensuelle des familles, disponible en PDF dans l'espace facturation.",
+  },
+  {
+    title: 'Exporter le planning d\'une nounou',
+    desc: "Depuis la fiche d'un intervenant, un export PDF de son planning mensuel est disponible pour archivage ou transmission administrative.",
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    q: 'Qui peut créer un rapport d\'activité ?',
+    a: "Les administrateurs et les nounous peuvent créer un rapport (incident, comportement ou soin) pour un enfant. Les parents ne créent pas de rapport mais peuvent consulter ceux concernant leur enfant.",
+  },
+  {
+    q: 'Peut-on exporter les rapports en PDF ou Excel ?',
+    a: "Les rapports d'activité se consultent et se filtrent directement dans l'application. L'export PDF est disponible pour les factures mensuelles et pour le planning d'un intervenant, depuis leurs rubriques respectives.",
+  },
+  {
+    q: 'Les parents voient-ils tous les rapports de la structure ?',
+    a: "Non, un parent ne voit que les rapports concernant son propre enfant. Une nounou ne voit que les rapports des enfants qui lui sont assignés.",
+  },
+  {
+    q: 'Comment retrouver un rapport ancien ?',
+    a: "Désactivez le filtre \"30 derniers jours\" et utilisez le filtre par type pour parcourir l'historique complet des rapports de la structure.",
+  },
+];
 
 export default function GuideExportReportPage() {
   return (
     <div className="min-h-screen w-full flex flex-col overflow-x-hidden bg-white">
       <SEO
-        title={"Exporter un rapport d'activite | Guide Frimousse - Logiciel creche"}
-        description={"Comment exporter un rapport d'activite dans Frimousse : consultation, filtrage, export PDF ou Excel. Guide pour creches, micro-creches et MAM."}
+        title={"Rapports d'activité et facturation | Guide Frimousse - Logiciel crèche"}
+        description={"Comment consulter, filtrer les rapports d'activité et exporter la facturation et le planning dans Frimousse. Guide pour crèches, micro-crèches et MAM."}
         url={"https://lesfrimousses.com/guide-export-rapport"}
         image={"https://lesfrimousses.com/imgs/og-banner.png"}
         type={"article"}
         breadcrumbs={[{ name: 'Accueil', url: 'https://lesfrimousses.com/' }, { name: 'Export rapport', url: 'https://lesfrimousses.com/guide-export-rapport' }]}
+        ldJson={buildFaqLd(FAQ_ITEMS)}
       />
       <PublicNavbar />
       <main className="flex-1 w-full">
@@ -24,37 +68,64 @@ export default function GuideExportReportPage() {
           <div className="relative z-10 max-w-3xl mx-auto text-center px-6">
             <span className="inline-block text-xs font-bold uppercase tracking-widest text-white bg-white/15 px-4 py-1.5 rounded-full mb-6 border border-white/20">Guide</span>
             <h1 className="text-4xl sm:text-5xl md:text-6xl font-extrabold !text-[#ffffff] leading-[1.1] tracking-tight mb-6">
-              Exporter un rapport
+              Rapports & facturation
             </h1>
             <p className="text-lg md:text-xl !text-[#ffffff] max-w-2xl mx-auto leading-relaxed">
-              Tutoriel pour exporter un rapport dans Frimousse : consultation, filtrage, export PDF ou Excel des rapports d'activité.
+              Consulter, filtrer les rapports d'activité et exporter la facturation ou le planning d'un intervenant.
             </p>
           </div>
           <div className="absolute bottom-0 left-0 right-0">
             <svg viewBox="0 0 1440 120" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full h-auto block"><path d="M0 120V60C240 15 480 0 720 25C960 50 1200 80 1440 50V120H0Z" fill="white"/></svg>
           </div>
         </section>
-        {/* ── Guide Card ── */}
-        <section className="py-20 md:py-24 px-6">
+
+        {/* ── Étapes ── */}
+        <section className="py-20 md:py-24 px-6 bg-white">
           <div className="max-w-3xl mx-auto">
-            <div className="bg-white rounded-3xl border border-gray-100 shadow-xl p-8">
-              <h2 className="text-2xl font-bold text-brand-700 mb-6 text-center">Exporter un rapport</h2>
-              <ol className="list-decimal list-inside text-gray-700 space-y-3 mb-6 text-left">
-                <li>Accédez à la rubrique "Rapports" via le menu.</li>
-                <li>Filtrez les rapports selon la période, le groupe ou l’intervenant.</li>
-                <li>Cliquez sur le rapport souhaité pour le consulter en détail.</li>
-                <li>Utilisez les options d'export pour générer un PDF ou un fichier Excel.</li>
-              </ol>
-              <div className="mt-8 text-gray-500 text-sm">Astuce : Utilisez les filtres pour retrouver rapidement le rapport souhaité.</div>
-              <div className="mt-10 flex flex-col sm:flex-row gap-4 justify-center items-center">
-                <Link to="/support" className="group bg-white text-brand-700 px-8 py-4 rounded-2xl font-bold text-lg shadow-xl shadow-black/10 hover:shadow-2xl transition-all hover:-translate-y-0.5 inline-flex items-center gap-3">
-                  Retour au support
-                  <svg className="w-5 h-5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"/></svg>
-                </Link>
-                <Link to="/" className="!text-[#ffffff] border-2 border-brand-500 hover:border-brand-600 px-8 py-4 rounded-2xl font-bold text-lg transition-all bg-brand-500 hover:bg-brand-600">
-                  Accueil
-                </Link>
-              </div>
+            <div className="text-center mb-12">
+              <span className="inline-block text-xs font-bold uppercase tracking-widest text-brand-500 bg-brand-50 px-4 py-1.5 rounded-full mb-4">Étape par étape</span>
+              <h2 className="text-3xl md:text-4xl font-extrabold text-gray-900 tracking-tight">Consulter et exporter</h2>
+            </div>
+            <ol className="space-y-6">
+              {STEPS.map((s, i) => (
+                <li key={i} className="flex gap-5 bg-gray-50 rounded-3xl border border-gray-100 p-6 md:p-8">
+                  <div className="flex-shrink-0 w-10 h-10 rounded-2xl bg-brand-500 text-white font-bold flex items-center justify-center">{i + 1}</div>
+                  <div>
+                    <h3 className="text-lg font-bold text-gray-900 mb-2">{s.title}</h3>
+                    <p className="text-gray-600 leading-relaxed">{s.desc}</p>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </section>
+
+        {/* ── FAQ ── */}
+        <section className="py-20 px-6 bg-gray-50">
+          <div className="max-w-3xl mx-auto">
+            <div className="text-center mb-12">
+              <span className="inline-block text-xs font-bold uppercase tracking-widest text-brand-500 bg-brand-50 px-4 py-1.5 rounded-full mb-4">FAQ</span>
+              <h2 className="text-3xl md:text-4xl font-extrabold text-gray-900 tracking-tight">Questions fréquentes sur les rapports</h2>
+            </div>
+            <div className="space-y-4">
+              {FAQ_ITEMS.map((item, i) => (
+                <details key={i} className="group bg-white rounded-2xl border border-gray-100 overflow-hidden">
+                  <summary className="flex items-center justify-between p-6 cursor-pointer font-semibold text-gray-900 list-none">
+                    {item.q}
+                    <svg className="w-5 h-5 text-brand-500 flex-shrink-0 ml-4 transition-transform group-open:rotate-180" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" /></svg>
+                  </summary>
+                  <div className="px-6 pb-6 text-gray-600 leading-relaxed">{item.a}</div>
+                </details>
+              ))}
+            </div>
+            <div className="mt-10 flex flex-col sm:flex-row gap-4 justify-center items-center">
+              <Link to="/support" className="group bg-white text-brand-700 px-8 py-4 rounded-2xl font-bold text-lg shadow-xl shadow-black/10 hover:shadow-2xl transition-all hover:-translate-y-0.5 inline-flex items-center gap-3 border border-gray-100">
+                Retour au support
+                <svg className="w-5 h-5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"/></svg>
+              </Link>
+              <Link to="/" className="!text-[#ffffff] border-2 border-brand-500 hover:border-brand-600 px-8 py-4 rounded-2xl font-bold text-lg transition-all bg-brand-500 hover:bg-brand-600">
+                Accueil
+              </Link>
             </div>
           </div>
         </section>

--- a/pages/GuidePlanningPage.tsx
+++ b/pages/GuidePlanningPage.tsx
@@ -1,18 +1,62 @@
 import SEO from '../components/SEO';
+import { buildFaqLd } from '../components/buildJsonLd';
 import PublicNavbar from '../components/PublicNavbar';
 import PublicFooter from '../components/PublicFooter';
 import { Link } from 'react-router-dom';
+
+const STEPS = [
+  {
+    title: 'Accéder au planning',
+    desc: "Depuis l'accueil (administrateurs) ou \"Mon planning\" (nounous), affichez le calendrier hebdomadaire ou mensuel des affectations enfants ↔ intervenants.",
+  },
+  {
+    title: 'Affecter un enfant à un intervenant',
+    desc: "Cliquez sur un créneau vide ou existant pour choisir l'enfant et l'intervenant concernés. L'affectation détermine qui a accès aux données de l'enfant ce jour-là (rapports, fiche, présence).",
+  },
+  {
+    title: 'Déclarer une absence ou un remplacement',
+    desc: "En cas d'absence (congé, maladie) d'un intervenant, réaffectez ses créneaux à un remplaçant directement depuis le planning. Les familles concernées sont notifiées si l'option est activée.",
+  },
+  {
+    title: 'Suivre les présences du jour',
+    desc: "La vue du jour affiche en un coup d'œil les enfants attendus, déjà arrivés ou absents. Ces présences alimentent directement les feuilles de présence mensuelles et la facturation.",
+  },
+  {
+    title: 'Modifier ou annuler une affectation',
+    desc: "Un administrateur peut réaffecter ou supprimer une entrée de planning à tout moment. Les modifications sont enregistrées immédiatement et visibles par toute l'équipe concernée.",
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    q: 'Qui peut modifier le planning ?',
+    a: "Les administrateurs de la structure peuvent créer et modifier toutes les affectations. Les nounous consultent leur propre planning et peuvent signaler une absence, mais ne modifient pas les affectations d'autres intervenants.",
+  },
+  {
+    q: 'Le planning est-il visible par les parents ?',
+    a: "Les parents voient uniquement le planning et les présences de leur propre enfant, jamais celui des autres familles ni la répartition complète de l'équipe.",
+  },
+  {
+    q: 'Comment gérer un remplacement de dernière minute ?',
+    a: "Depuis le planning, réaffectez simplement le créneau de l'intervenant absent à un remplaçant disponible. L'historique de présence de l'enfant reste inchangé, seul l'intervenant change.",
+  },
+  {
+    q: "Les présences du planning servent-elles à la facturation ?",
+    a: "Oui. Chaque présence enregistrée alimente automatiquement le calcul mensuel des cotisations familles, visible dans l'espace facturation.",
+  },
+];
 
 export default function GuidePlanningPage() {
   return (
     <div className="min-h-screen w-full flex flex-col overflow-x-hidden bg-white">
       <SEO
-        title={"Gerer le planning de garde | Guide Frimousse - Application creche"}
-        description={"Comment gerer le planning de garde dans Frimousse : visualisation calendrier, modification des presences, gestion des absences. Tutoriel pour creches et MAM."}
+        title={"Gérer le planning de garde | Guide Frimousse - Application crèche"}
+        description={"Comment gérer le planning de garde dans Frimousse : affectation enfant/intervenant, absences, remplacements, suivi des présences. Tutoriel pour crèches, micro-crèches et MAM."}
         url={"https://lesfrimousses.com/guide-planning"}
         image={"https://lesfrimousses.com/imgs/og-banner.png"}
         type={"article"}
         breadcrumbs={[{ name: 'Accueil', url: 'https://lesfrimousses.com/' }, { name: 'Guide planning', url: 'https://lesfrimousses.com/guide-planning' }]}
+        ldJson={buildFaqLd(FAQ_ITEMS)}
       />
       <PublicNavbar />
       <main className="flex-1 w-full">
@@ -27,35 +71,61 @@ export default function GuidePlanningPage() {
               Gérer un planning
             </h1>
             <p className="text-lg md:text-xl !text-[#ffffff] max-w-2xl mx-auto leading-relaxed">
-              Tutoriel pour gérer le planning dans Frimousse : visualisation, modification, gestion des absences et présences.
+              Affectation, absences, remplacements et suivi des présences : le guide complet du planning de garde.
             </p>
           </div>
           <div className="absolute bottom-0 left-0 right-0">
             <svg viewBox="0 0 1440 120" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full h-auto block"><path d="M0 120V60C240 15 480 0 720 25C960 50 1200 80 1440 50V120H0Z" fill="white"/></svg>
           </div>
         </section>
-        {/* ── Guide Card ── */}
-        <section className="py-20 md:py-24 px-6">
+
+        {/* ── Étapes ── */}
+        <section className="py-20 md:py-24 px-6 bg-white">
           <div className="max-w-3xl mx-auto">
-            <div className="bg-white rounded-3xl border border-gray-100 shadow-xl p-8">
-              <h2 className="text-2xl font-bold text-brand-700 mb-6 text-center">Gérer un planning</h2>
-              <ol className="list-decimal list-inside text-gray-700 space-y-3 mb-6 text-left">
-                <li>Accédez à la rubrique "Mon planning" via le menu.</li>
-                <li>Visualisez le planning de garde sous forme de calendrier.</li>
-                <li>Pour modifier une garde, cliquez sur le créneau souhaité et suivez les instructions.</li>
-                <li>Les absences et présences sont gérées directement dans le calendrier.</li>
-                <li>Les modifications sont enregistrées automatiquement et visibles par les intervenants concernés.</li>
-              </ol>
-              <div className="mt-8 text-gray-500 text-sm">Seuls les utilisateurs autorisés peuvent modifier le planning.</div>
-              <div className="mt-10 flex flex-col sm:flex-row gap-4 justify-center items-center">
-                <Link to="/support" className="group bg-white text-brand-700 px-8 py-4 rounded-2xl font-bold text-lg shadow-xl shadow-black/10 hover:shadow-2xl transition-all hover:-translate-y-0.5 inline-flex items-center gap-3">
-                  Retour au support
-                  <svg className="w-5 h-5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"/></svg>
-                </Link>
-                <Link to="/" className="!text-[#ffffff] border-2 border-brand-500 hover:border-brand-600 px-8 py-4 rounded-2xl font-bold text-lg transition-all bg-brand-500 hover:bg-brand-600">
-                  Accueil
-                </Link>
-              </div>
+            <div className="text-center mb-12">
+              <span className="inline-block text-xs font-bold uppercase tracking-widest text-brand-500 bg-brand-50 px-4 py-1.5 rounded-full mb-4">Étape par étape</span>
+              <h2 className="text-3xl md:text-4xl font-extrabold text-gray-900 tracking-tight">Gérer le planning au quotidien</h2>
+            </div>
+            <ol className="space-y-6">
+              {STEPS.map((s, i) => (
+                <li key={i} className="flex gap-5 bg-gray-50 rounded-3xl border border-gray-100 p-6 md:p-8">
+                  <div className="flex-shrink-0 w-10 h-10 rounded-2xl bg-brand-500 text-white font-bold flex items-center justify-center">{i + 1}</div>
+                  <div>
+                    <h3 className="text-lg font-bold text-gray-900 mb-2">{s.title}</h3>
+                    <p className="text-gray-600 leading-relaxed">{s.desc}</p>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </section>
+
+        {/* ── FAQ ── */}
+        <section className="py-20 px-6 bg-gray-50">
+          <div className="max-w-3xl mx-auto">
+            <div className="text-center mb-12">
+              <span className="inline-block text-xs font-bold uppercase tracking-widest text-brand-500 bg-brand-50 px-4 py-1.5 rounded-full mb-4">FAQ</span>
+              <h2 className="text-3xl md:text-4xl font-extrabold text-gray-900 tracking-tight">Questions fréquentes sur le planning</h2>
+            </div>
+            <div className="space-y-4">
+              {FAQ_ITEMS.map((item, i) => (
+                <details key={i} className="group bg-white rounded-2xl border border-gray-100 overflow-hidden">
+                  <summary className="flex items-center justify-between p-6 cursor-pointer font-semibold text-gray-900 list-none">
+                    {item.q}
+                    <svg className="w-5 h-5 text-brand-500 flex-shrink-0 ml-4 transition-transform group-open:rotate-180" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" /></svg>
+                  </summary>
+                  <div className="px-6 pb-6 text-gray-600 leading-relaxed">{item.a}</div>
+                </details>
+              ))}
+            </div>
+            <div className="mt-10 flex flex-col sm:flex-row gap-4 justify-center items-center">
+              <Link to="/support" className="group bg-white text-brand-700 px-8 py-4 rounded-2xl font-bold text-lg shadow-xl shadow-black/10 hover:shadow-2xl transition-all hover:-translate-y-0.5 inline-flex items-center gap-3 border border-gray-100">
+                Retour au support
+                <svg className="w-5 h-5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"/></svg>
+              </Link>
+              <Link to="/" className="!text-[#ffffff] border-2 border-brand-500 hover:border-brand-600 px-8 py-4 rounded-2xl font-bold text-lg transition-all bg-brand-500 hover:bg-brand-600">
+                Accueil
+              </Link>
             </div>
           </div>
         </section>

--- a/pages/GuideSecurityPage.tsx
+++ b/pages/GuideSecurityPage.tsx
@@ -1,8 +1,28 @@
 
 import SEO from '../components/SEO';
+import { buildFaqLd } from '../components/buildJsonLd';
 import PublicNavbar from '../components/PublicNavbar';
 import PublicFooter from '../components/PublicFooter';
 import { useNavigate } from 'react-router-dom';
+
+const FAQ_ITEMS = [
+  {
+    q: 'Les photos des enfants sont-elles stockées de façon sécurisée ?',
+    a: "Oui, les photos et documents des enfants sont stockés dans un espace privé et ne sont jamais accessibles par une URL publique directe. Seuls les utilisateurs autorisés (équipe de la structure et parents liés à l'enfant) peuvent les consulter.",
+  },
+  {
+    q: 'Qui a accès aux données médicales des enfants ?',
+    a: "Uniquement l'équipe encadrante de la structure (nounous assignées à l'enfant, administrateurs) et les parents liés à l'enfant. Aucune autre famille ni aucun autre intervenant n'y a accès.",
+  },
+  {
+    q: 'Frimousse est-il hébergé en France ou en Europe ?',
+    a: "Les données sont hébergées chez des prestataires conformes au RGPD. Un registre des traitements est tenu conformément à l'Article 30 du RGPD et peut être consulté sur demande.",
+  },
+  {
+    q: "Comment un parent peut-il exercer son droit à l'oubli ?",
+    a: "Un parent peut demander la suppression de ses données et de celles de son enfant depuis les paramètres de son compte ou en contactant le support. La demande est traitée conformément aux délais prévus par le RGPD.",
+  },
+];
 
 export default function GuideSecurityPage() {
   const navigate = useNavigate();
@@ -15,6 +35,7 @@ export default function GuideSecurityPage() {
         image={"https://lesfrimousses.com/imgs/og-banner.png"}
         type={"article"}
         breadcrumbs={[{ name: 'Accueil', url: 'https://lesfrimousses.com/' }, { name: 'Guide securite', url: 'https://lesfrimousses.com/guide-securite' }]}
+        ldJson={buildFaqLd(FAQ_ITEMS)}
       />
 
       <PublicNavbar variant="dark" />
@@ -98,6 +119,27 @@ export default function GuideSecurityPage() {
                 <h3 className="text-xl font-bold text-gray-900 mb-3">{v.title}</h3>
                 <p className="text-gray-500 leading-relaxed">{v.desc}</p>
               </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ section */}
+      <section className="py-20 px-6 bg-gray-50">
+        <div className="max-w-3xl mx-auto">
+          <div className="text-center mb-12">
+            <span className="inline-block text-xs font-bold uppercase tracking-widest text-brand-500 bg-brand-50 px-4 py-1.5 rounded-full mb-4">FAQ</span>
+            <h2 className="text-3xl md:text-4xl font-extrabold text-gray-900 tracking-tight">Questions fréquentes sur la sécurité et le RGPD</h2>
+          </div>
+          <div className="space-y-4">
+            {FAQ_ITEMS.map((item, i) => (
+              <details key={i} className="group bg-white rounded-2xl border border-gray-100 overflow-hidden">
+                <summary className="flex items-center justify-between p-6 cursor-pointer font-semibold text-gray-900 list-none">
+                  {item.q}
+                  <svg className="w-5 h-5 text-brand-500 flex-shrink-0 ml-4 transition-transform group-open:rotate-180" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" /></svg>
+                </summary>
+                <div className="px-6 pb-6 text-gray-600 leading-relaxed">{item.a}</div>
+              </details>
             ))}
           </div>
         </div>

--- a/pages/GuideStartPage.tsx
+++ b/pages/GuideStartPage.tsx
@@ -1,18 +1,70 @@
 import SEO from '../components/SEO';
+import { buildFaqLd } from '../components/buildJsonLd';
 import PublicNavbar from '../components/PublicNavbar';
 import PublicFooter from '../components/PublicFooter';
 import { Link } from 'react-router-dom';
+
+const STEPS = [
+  {
+    title: 'Connexion à votre espace',
+    desc: "Rendez-vous sur la page d'accueil et cliquez sur \"Se connecter\". Utilisez l'email et le mot de passe fournis lors de la création de votre structure (crèche, micro-crèche ou MAM). Si vous avez été invité par un administrateur, suivez le lien reçu par email pour définir votre mot de passe.",
+  },
+  {
+    title: 'Découvrir la navigation',
+    desc: "Le menu principal donne accès aux rubriques Enfants, Nounous, Parents, Planning, Rapports et Fil d'actualité. Sur mobile, ce menu est accessible via l'icône en haut de l'écran. Le tableau de bord d'accueil résume les présences du jour et les activités à venir.",
+  },
+  {
+    title: 'Ajouter votre équipe',
+    desc: "Depuis la rubrique \"Nounous\", cliquez sur \"Ajouter\" et renseignez le nom, l'expérience et les coordonnées de chaque intervenant. Chacun reçoit ensuite ses identifiants pour accéder à son propre planning.",
+  },
+  {
+    title: 'Ajouter les familles',
+    desc: "Depuis \"Parents\", créez une fiche par famille (nom, email, téléphone). Un compte parent est automatiquement proposé pour qu'ils suivent l'activité de leur enfant depuis leur smartphone.",
+  },
+  {
+    title: 'Créer les fiches enfants',
+    desc: "Dans \"Enfants\", ajoutez chaque enfant accueilli avec ses informations essentielles : date de naissance, allergies, informations médicales, contacts d'urgence, et le lien vers ses parents. Consultez notre guide dédié pour le détail de cette étape.",
+  },
+  {
+    title: 'Construire le planning',
+    desc: "Depuis l'accueil, affectez chaque enfant à un intervenant pour la semaine ou le mois. Les absences et remplacements se gèrent directement depuis cette vue, visible en temps réel par toute l'équipe.",
+  },
+  {
+    title: 'Suivre les rapports et la facturation',
+    desc: "La rubrique \"Rapports\" centralise les rapports d'activité journaliers. Les présences enregistrées alimentent automatiquement la facturation mensuelle des familles, consultable dans l'espace dédié.",
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    q: 'Combien de temps faut-il pour configurer Frimousse ?',
+    a: "Pour une petite structure (MAM, micro-crèche), compter environ 30 minutes pour créer les fiches de l'équipe et des premières familles. L'ajout des enfants prend quelques minutes par dossier. Aucune formation technique n'est nécessaire.",
+  },
+  {
+    q: "Puis-je importer mes données existantes (Excel, ancien logiciel) ?",
+    a: "Oui, un import par fichier Excel est disponible pour les nounous, parents et enfants (menu Import, réservé aux administrateurs). Notre équipe peut aussi vous accompagner pour une migration depuis un autre outil.",
+  },
+  {
+    q: 'Que voient les parents une fois leur compte créé ?',
+    a: "Les parents accèdent à un espace limité à leur propre enfant : planning, rapports d'activité, fil d'actualité avec photos (selon leur consentement) et messagerie avec l'équipe. Ils ne voient jamais les données des autres familles.",
+  },
+  {
+    q: "Comment inviter un nouvel intervenant en cours d'année ?",
+    a: "Un administrateur crée sa fiche depuis la rubrique Nounous ; l'intervenant reçoit un email d'invitation pour activer son compte et définir son mot de passe.",
+  },
+];
 
 export default function GuideStartPage() {
   return (
     <div className="min-h-screen w-full flex flex-col overflow-x-hidden bg-white">
       <SEO
-        title={"Guide de demarrage rapide | Frimousse - Logiciel de gestion creche"}
-        description={"Premiers pas sur Frimousse : connexion, navigation, ajout d'enfants, gestion du planning, acces aux rapports. Tutoriel complet pour creches, micro-creches et MAM."}
+        title={"Guide de démarrage rapide | Frimousse - Logiciel de gestion crèche"}
+        description={"Premiers pas sur Frimousse : connexion, navigation, ajout de l'équipe, des familles et des enfants, planning et facturation. Tutoriel complet pour crèches, micro-crèches et MAM."}
         url={"https://lesfrimousses.com/guide-demarrage"}
         image={"https://lesfrimousses.com/imgs/og-banner.png"}
         type={"article"}
-        breadcrumbs={[{ name: 'Accueil', url: 'https://lesfrimousses.com/' }, { name: 'Guide demarrage', url: 'https://lesfrimousses.com/guide-demarrage' }]}
+        breadcrumbs={[{ name: 'Accueil', url: 'https://lesfrimousses.com/' }, { name: 'Guide démarrage', url: 'https://lesfrimousses.com/guide-demarrage' }]}
+        ldJson={buildFaqLd(FAQ_ITEMS)}
       />
       <PublicNavbar />
       <main className="flex-1 w-full">
@@ -27,38 +79,64 @@ export default function GuideStartPage() {
               Démarrez avec Frimousse
             </h1>
             <p className="text-lg md:text-xl !text-[#ffffff] max-w-2xl mx-auto leading-relaxed">
-              Premiers pas : connexion, navigation, ajout d'enfants, gestion du planning, accès aux rapports.
+              De la connexion à la facturation : les 7 étapes pour mettre en place votre structure sur Frimousse.
             </p>
           </div>
           <div className="absolute bottom-0 left-0 right-0">
             <svg viewBox="0 0 1440 120" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full h-auto block"><path d="M0 120V60C240 15 480 0 720 25C960 50 1200 80 1440 50V120H0Z" fill="white"/></svg>
           </div>
         </section>
-        {/* ── Guide Card ── */}
-        <section className="py-20 md:py-24 px-6">
+
+        {/* ── Étapes ── */}
+        <section className="py-20 md:py-24 px-6 bg-white">
           <div className="max-w-3xl mx-auto">
-            <div className="bg-white rounded-3xl border border-gray-100 shadow-xl p-8">
-              <h2 className="text-2xl font-bold text-brand-700 mb-6 text-center">Guide de démarrage rapide</h2>
-              <ol className="list-decimal list-inside text-gray-700 space-y-3 mb-6 text-left">
-                <li><strong>Connexion :</strong> Rendez-vous sur la page d'accueil, cliquez sur "Se connecter" et saisissez vos identifiants fournis par l'association.</li>
-                <li><strong>Navigation :</strong> Utilisez le menu pour accéder aux rubriques : Enfants, Planning, Rapports, etc.</li>
-                <li><strong>Ajouter une nounou :</strong> Depuis la rubrique "Nounou", cliquez sur "Ajouter" et remplissez le formulaire (nom, âge, expérience, etc.).</li>
-                <li><strong>Ajouter un parent :</strong> Depuis la rubrique "Parents", cliquez sur "Ajouter" et remplissez le formulaire (nom, âge, contacts,  etc.).</li>
-                <li><strong>Ajouter un enfant :</strong> Depuis la rubrique "Enfants", cliquez sur "Ajouter" et remplissez le formulaire (nom, âge, contacts, allergies, etc.).</li>
-                <li><strong>Gérer le planning :</strong> Accédez à "Accueil" pour visualiser et modifier les plannings de garde.</li>
-                <li><strong>Consulter un rapport :</strong> Dans "Rapports", filtrez et consultez les rapports d'activité.</li>
-                <li><strong>Besoin d’aide ?</strong> Consultez la page <Link to="/support" className="text-brand-600 underline">Support</Link> ou contactez l’équipe Frimousse.</li>
-              </ol>
-              <div className="mt-8 text-gray-500 text-sm">Pour plus de détails, consultez les guides spécifiques ou contactez le support via les paramètres de votre compte.</div>
-              <div className="mt-10 flex flex-col sm:flex-row gap-4 justify-center items-center">
-                <Link to="/" className="group bg-white text-brand-700 px-8 py-4 rounded-2xl font-bold text-lg shadow-xl shadow-black/10 hover:shadow-2xl transition-all hover:-translate-y-0.5 inline-flex items-center gap-3">
-                  Retour à l'accueil
-                  <svg className="w-5 h-5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"/></svg>
-                </Link>
-                <Link to="/support" className="!text-[#ffffff] border-2 border-brand-500 hover:border-brand-600 px-8 py-4 rounded-2xl font-bold text-lg transition-all bg-brand-500 hover:bg-brand-600">
-                  Besoin d'aide ?
-                </Link>
-              </div>
+            <div className="text-center mb-12">
+              <span className="inline-block text-xs font-bold uppercase tracking-widest text-brand-500 bg-brand-50 px-4 py-1.5 rounded-full mb-4">Étape par étape</span>
+              <h2 className="text-3xl md:text-4xl font-extrabold text-gray-900 tracking-tight">Guide de démarrage rapide</h2>
+            </div>
+            <ol className="space-y-6">
+              {STEPS.map((s, i) => (
+                <li key={i} className="flex gap-5 bg-gray-50 rounded-3xl border border-gray-100 p-6 md:p-8">
+                  <div className="flex-shrink-0 w-10 h-10 rounded-2xl bg-brand-500 text-white font-bold flex items-center justify-center">{i + 1}</div>
+                  <div>
+                    <h3 className="text-lg font-bold text-gray-900 mb-2">{s.title}</h3>
+                    <p className="text-gray-600 leading-relaxed">{s.desc}</p>
+                  </div>
+                </li>
+              ))}
+            </ol>
+            <div className="mt-10 text-gray-500 text-sm text-center">
+              Besoin d'un détail sur une étape précise ? Consultez nos guides <Link to="/guide-ajouter-enfant" className="text-brand-600 underline">ajouter un enfant</Link>, <Link to="/guide-planning" className="text-brand-600 underline">gérer le planning</Link> et <Link to="/guide-export-rapport" className="text-brand-600 underline">exporter un rapport</Link>.
+            </div>
+          </div>
+        </section>
+
+        {/* ── FAQ ── */}
+        <section className="py-20 px-6 bg-gray-50">
+          <div className="max-w-3xl mx-auto">
+            <div className="text-center mb-12">
+              <span className="inline-block text-xs font-bold uppercase tracking-widest text-brand-500 bg-brand-50 px-4 py-1.5 rounded-full mb-4">FAQ</span>
+              <h2 className="text-3xl md:text-4xl font-extrabold text-gray-900 tracking-tight">Questions fréquentes sur la prise en main</h2>
+            </div>
+            <div className="space-y-4">
+              {FAQ_ITEMS.map((item, i) => (
+                <details key={i} className="group bg-white rounded-2xl border border-gray-100 overflow-hidden">
+                  <summary className="flex items-center justify-between p-6 cursor-pointer font-semibold text-gray-900 list-none">
+                    {item.q}
+                    <svg className="w-5 h-5 text-brand-500 flex-shrink-0 ml-4 transition-transform group-open:rotate-180" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" /></svg>
+                  </summary>
+                  <div className="px-6 pb-6 text-gray-600 leading-relaxed">{item.a}</div>
+                </details>
+              ))}
+            </div>
+            <div className="mt-10 flex flex-col sm:flex-row gap-4 justify-center items-center">
+              <Link to="/" className="group bg-white text-brand-700 px-8 py-4 rounded-2xl font-bold text-lg shadow-xl shadow-black/10 hover:shadow-2xl transition-all hover:-translate-y-0.5 inline-flex items-center gap-3 border border-gray-100">
+                Retour à l'accueil
+                <svg className="w-5 h-5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"/></svg>
+              </Link>
+              <Link to="/support" className="!text-[#ffffff] border-2 border-brand-500 hover:border-brand-600 px-8 py-4 rounded-2xl font-bold text-lg transition-all bg-brand-500 hover:bg-brand-600">
+                Besoin d'aide ?
+              </Link>
             </div>
           </div>
         </section>

--- a/pages/LandingCrechePage.tsx
+++ b/pages/LandingCrechePage.tsx
@@ -1,7 +1,31 @@
 import SEO from '../components/SEO';
+import { buildFaqLd } from '../components/buildJsonLd';
 import PublicNavbar from '../components/PublicNavbar';
 import PublicFooter from '../components/PublicFooter';
 import { Link } from 'react-router-dom';
+
+const FAQ_ITEMS = [
+  {
+    q: "Quel logiciel pour gérer une crèche associative ?",
+    a: "Les Frimousses est un logiciel de gestion crèche complet, pensé pour les crèches associatives et parentales. Il couvre les inscriptions, le planning des intervenants, le suivi des enfants, la communication avec les parents et les rapports d'activité. Essai gratuit sans engagement.",
+  },
+  {
+    q: "Le logiciel convient-il aux crèches parentales ?",
+    a: "Oui, Les Frimousses est parfaitement adapté aux crèches parentales. Les parents-bénévoles peuvent accéder à l'application selon les droits définis par le gestionnaire. La transparence et la communication sont au cœur de nos fonctionnalités.",
+  },
+  {
+    q: "Peut-on gérer plusieurs groupes d'enfants dans la crèche ?",
+    a: "Oui, l'application permet de créer plusieurs groupes (bébés, moyens, grands) et d'affecter les intervenants et enfants à chaque groupe. Les plannings et fiches sont filtrables par groupe.",
+  },
+  {
+    q: "Les Frimousses est-il accessible sur smartphone ?",
+    a: "Oui, Les Frimousses est une application web responsive, accessible depuis n'importe quel navigateur sur ordinateur, tablette et smartphone. Les éducatrices peuvent noter les présences et partager des photos directement depuis le terrain.",
+  },
+  {
+    q: "Comment migrer depuis mon ancien logiciel de crèche ?",
+    a: "Notre équipe vous accompagne lors de la migration. Les données existantes (enfants, familles, plannings) peuvent être importées. Un guide de démarrage et un support humain sont disponibles pour assurer une transition sans rupture.",
+  },
+];
 
 export default function LandingCrechePage() {
   return (
@@ -15,6 +39,7 @@ export default function LandingCrechePage() {
           { name: 'Accueil', url: 'https://lesfrimousses.com/' },
           { name: 'Logiciel crèche', url: 'https://lesfrimousses.com/logiciel-creche' },
         ]}
+        ldJson={buildFaqLd(FAQ_ITEMS)}
       />
       <PublicNavbar variant="dark" />
 
@@ -139,28 +164,7 @@ export default function LandingCrechePage() {
             <h2 className="text-3xl md:text-4xl font-extrabold text-gray-900 tracking-tight">Questions fréquentes sur la gestion de crèche</h2>
           </div>
           <div className="space-y-4">
-            {[
-              {
-                q: "Quel logiciel pour gérer une crèche associative ?",
-                a: "Les Frimousses est un logiciel de gestion crèche complet, pensé pour les crèches associatives et parentales. Il couvre les inscriptions, le planning des intervenants, le suivi des enfants, la communication avec les parents et les rapports d'activité. Essai gratuit sans engagement.",
-              },
-              {
-                q: "Le logiciel convient-il aux crèches parentales ?",
-                a: "Oui, Les Frimousses est parfaitement adapté aux crèches parentales. Les parents-bénévoles peuvent accéder à l'application selon les droits définis par le gestionnaire. La transparence et la communication sont au cœur de nos fonctionnalités.",
-              },
-              {
-                q: "Peut-on gérer plusieurs groupes d'enfants dans la crèche ?",
-                a: "Oui, l'application permet de créer plusieurs groupes (bébés, moyens, grands) et d'affecter les intervenants et enfants à chaque groupe. Les plannings et fiches sont filtrables par groupe.",
-              },
-              {
-                q: "Les Frimousses est-il accessible sur smartphone ?",
-                a: "Oui, Les Frimousses est une application web responsive, accessible depuis n'importe quel navigateur sur ordinateur, tablette et smartphone. Les éducatrices peuvent noter les présences et partager des photos directement depuis le terrain.",
-              },
-              {
-                q: "Comment migrer depuis mon ancien logiciel de crèche ?",
-                a: "Notre équipe vous accompagne lors de la migration. Les données existantes (enfants, familles, plannings) peuvent être importées. Un guide de démarrage et un support humain sont disponibles pour assurer une transition sans rupture.",
-              },
-            ].map((item, i) => (
+            {FAQ_ITEMS.map((item, i) => (
               <details key={i} className="group bg-gray-50 rounded-2xl border border-gray-100 overflow-hidden">
                 <summary className="flex items-center justify-between p-6 cursor-pointer font-semibold text-gray-900 list-none">
                   {item.q}

--- a/pages/LandingMAMPage.tsx
+++ b/pages/LandingMAMPage.tsx
@@ -1,7 +1,31 @@
 import SEO from '../components/SEO';
+import { buildFaqLd } from '../components/buildJsonLd';
 import PublicNavbar from '../components/PublicNavbar';
 import PublicFooter from '../components/PublicFooter';
 import { Link } from 'react-router-dom';
+
+const FAQ_ITEMS = [
+  {
+    q: "Quel logiciel pour gérer une MAM ?",
+    a: "Les Frimousses est spécialement conçu pour les Maisons d'Assistantes Maternelles. Il permet à chaque assistante maternelle de gérer son planning et ses enfants de façon indépendante, tout en partageant la structure commune. L'application est accessible sur ordinateur, tablette et smartphone.",
+  },
+  {
+    q: "Le logiciel est-il adapté à plusieurs assistantes maternelles ?",
+    a: "Oui, Les Frimousses gère le multi-utilisateurs nativement. Chaque assistante maternelle a son propre accès, ses propres fiches enfants et son planning. La responsable de la MAM dispose d'une vue d'ensemble sur toute la structure.",
+  },
+  {
+    q: "Les Frimousses génère-t-il les rapports pour la PMI ?",
+    a: "Les Frimousses génère automatiquement les rapports d'activité mensuels avec les données de présence, heures de garde et activités. Ces exports facilitent les déclarations auprès de la PMI et de la CAF.",
+  },
+  {
+    q: "Faut-il être informaticien pour utiliser ce logiciel MAM ?",
+    a: "Non. Les Frimousses est conçu pour être utilisé au quotidien sans formation technique. L'interface est intuitive, mobile-first, et notre équipe vous accompagne lors de la prise en main.",
+  },
+  {
+    q: "Quel est le prix du logiciel pour une MAM ?",
+    a: "Les Frimousses propose un essai gratuit sans engagement. Les tarifs démarrent à partir de 29,99 €/mois pour les petites structures. Consultez notre page tarifs pour le détail des offres adaptées aux MAM.",
+  },
+];
 
 export default function LandingMAMPage() {
   return (
@@ -15,6 +39,7 @@ export default function LandingMAMPage() {
           { name: 'Accueil', url: 'https://lesfrimousses.com/' },
           { name: 'Logiciel MAM', url: 'https://lesfrimousses.com/logiciel-mam' },
         ]}
+        ldJson={buildFaqLd(FAQ_ITEMS)}
       />
       <PublicNavbar variant="dark" />
 
@@ -139,28 +164,7 @@ export default function LandingMAMPage() {
             <h2 className="text-3xl md:text-4xl font-extrabold text-gray-900 tracking-tight">Questions fréquentes sur la gestion MAM</h2>
           </div>
           <div className="space-y-4">
-            {[
-              {
-                q: "Quel logiciel pour gérer une MAM ?",
-                a: "Les Frimousses est spécialement conçu pour les Maisons d'Assistantes Maternelles. Il permet à chaque assistante maternelle de gérer son planning et ses enfants de façon indépendante, tout en partageant la structure commune. L'application est accessible sur ordinateur, tablette et smartphone.",
-              },
-              {
-                q: "Le logiciel est-il adapté à plusieurs assistantes maternelles ?",
-                a: "Oui, Les Frimousses gère le multi-utilisateurs nativement. Chaque assistante maternelle a son propre accès, ses propres fiches enfants et son planning. La responsable de la MAM dispose d'une vue d'ensemble sur toute la structure.",
-              },
-              {
-                q: "Les Frimousses génère-t-il les rapports pour la PMI ?",
-                a: "Les Frimousses génère automatiquement les rapports d'activité mensuels avec les données de présence, heures de garde et activités. Ces exports facilitent les déclarations auprès de la PMI et de la CAF.",
-              },
-              {
-                q: "Faut-il être informaticien pour utiliser ce logiciel MAM ?",
-                a: "Non. Les Frimousses est conçu pour être utilisé au quotidien sans formation technique. L'interface est intuitive, mobile-first, et notre équipe vous accompagne lors de la prise en main.",
-              },
-              {
-                q: "Quel est le prix du logiciel pour une MAM ?",
-                a: "Les Frimousses propose un essai gratuit sans engagement. Les tarifs démarrent à partir de 29,99 €/mois pour les petites structures. Consultez notre page tarifs pour le détail des offres adaptées aux MAM.",
-              },
-            ].map((item, i) => (
+            {FAQ_ITEMS.map((item, i) => (
               <details key={i} className="group bg-gray-50 rounded-2xl border border-gray-100 overflow-hidden">
                 <summary className="flex items-center justify-between p-6 cursor-pointer font-semibold text-gray-900 list-none">
                   {item.q}

--- a/pages/LandingMicroCrechePage.tsx
+++ b/pages/LandingMicroCrechePage.tsx
@@ -1,7 +1,31 @@
 import SEO from '../components/SEO';
+import { buildFaqLd } from '../components/buildJsonLd';
 import PublicNavbar from '../components/PublicNavbar';
 import PublicFooter from '../components/PublicFooter';
 import { Link } from 'react-router-dom';
+
+const FAQ_ITEMS = [
+  {
+    q: "Quel logiciel pour gérer une micro-crèche ?",
+    a: "Les Frimousses est un logiciel de gestion micro-crèche conçu pour les petites structures jusqu'à 12 enfants. Il couvre le planning, les fiches enfants, la communication avec les parents et les rapports d'activité. Simple à prendre en main, accessible sur tous les appareils.",
+  },
+  {
+    q: "Combien coûte un logiciel de gestion pour micro-crèche ?",
+    a: "Les Frimousses propose un essai gratuit sans engagement. L'abonnement pour les petites structures (micro-crèches) démarre à partir de 29,99 €/mois. Consultez notre page tarifs pour les détails.",
+  },
+  {
+    q: "Le logiciel fonctionne-t-il sans connexion internet ?",
+    a: "Les Frimousses est une application web qui nécessite une connexion internet. Cependant, certaines données sont mises en cache pour fonctionner en mode hors ligne partiel. Une connexion même basique (4G) suffit pour une utilisation normale.",
+  },
+  {
+    q: "Peut-on utiliser Les Frimousses sur tablette ?",
+    a: "Oui, Les Frimousses est optimisé pour tablette et smartphone. L'interface s'adapte automatiquement à la taille de l'écran. Idéal pour une utilisation en salle d'accueil avec une tablette affichant le planning du jour.",
+  },
+  {
+    q: "Comment Les Frimousses aide pour la facturation de la micro-crèche ?",
+    a: "L'application trace automatiquement les heures de présence de chaque enfant. En fin de mois, vous exportez les données pour calculer les factures familles et préparer vos déclarations auprès de la CAF et des organismes de financement.",
+  },
+];
 
 export default function LandingMicroCrechePage() {
   return (
@@ -15,6 +39,7 @@ export default function LandingMicroCrechePage() {
           { name: 'Accueil', url: 'https://lesfrimousses.com/' },
           { name: 'Logiciel micro-crèche', url: 'https://lesfrimousses.com/logiciel-micro-creche' },
         ]}
+        ldJson={buildFaqLd(FAQ_ITEMS)}
       />
       <PublicNavbar variant="dark" />
 
@@ -139,28 +164,7 @@ export default function LandingMicroCrechePage() {
             <h2 className="text-3xl md:text-4xl font-extrabold text-gray-900 tracking-tight">Questions fréquentes sur la gestion de micro-crèche</h2>
           </div>
           <div className="space-y-4">
-            {[
-              {
-                q: "Quel logiciel pour gérer une micro-crèche ?",
-                a: "Les Frimousses est un logiciel de gestion micro-crèche conçu pour les petites structures jusqu'à 12 enfants. Il couvre le planning, les fiches enfants, la communication avec les parents et les rapports d'activité. Simple à prendre en main, accessible sur tous les appareils.",
-              },
-              {
-                q: "Combien coûte un logiciel de gestion pour micro-crèche ?",
-                a: "Les Frimousses propose un essai gratuit sans engagement. L'abonnement pour les petites structures (micro-crèches) démarre à partir de 29,99 €/mois. Consultez notre page tarifs pour les détails.",
-              },
-              {
-                q: "Le logiciel fonctionne-t-il sans connexion internet ?",
-                a: "Les Frimousses est une application web qui nécessite une connexion internet. Cependant, certaines données sont mises en cache pour fonctionner en mode hors ligne partiel. Une connexion même basique (4G) suffit pour une utilisation normale.",
-              },
-              {
-                q: "Peut-on utiliser Les Frimousses sur tablette ?",
-                a: "Oui, Les Frimousses est optimisé pour tablette et smartphone. L'interface s'adapte automatiquement à la taille de l'écran. Idéal pour une utilisation en salle d'accueil avec une tablette affichant le planning du jour.",
-              },
-              {
-                q: "Comment Les Frimousses aide pour la facturation de la micro-crèche ?",
-                a: "L'application trace automatiquement les heures de présence de chaque enfant. En fin de mois, vous exportez les données pour calculer les factures familles et préparer vos déclarations auprès de la CAF et des organismes de financement.",
-              },
-            ].map((item, i) => (
+            {FAQ_ITEMS.map((item, i) => (
               <details key={i} className="group bg-gray-50 rounded-2xl border border-gray-100 overflow-hidden">
                 <summary className="flex items-center justify-between p-6 cursor-pointer font-semibold text-gray-900 list-none">
                   {item.q}


### PR DESCRIPTION
…O content

RGPD retention (backend):
- Add User.lastLoginAt, set on every password login and OAuth login (both loginAndRedirect and loginAndRespond flows in oauth.js).
- dataRetentionCron's 2-year inactive-account anonymization now checks lastLoginAt (falling back to updatedAt for pre-migration accounts that have never logged in since), replacing the previous updatedAt-only heuristic which could be skewed by non-login profile updates.

SEO/AEO (frontend):
- Add buildFaqLd() helper to turn an on-page FAQ accordion into a FAQPage JSON-LD block; wired into the MAM/crèche/micro-crèche landing pages and the security guide, which previously had a visible FAQ with no matching structured data (only the homepage had FAQPage markup).
- Rewrite the 4 stub guide pages (démarrage, ajouter un enfant, planning, export rapport) with real step-by-step content grounded in the actual app forms/flows, plus a dedicated FAQ per guide, replacing the ~65-line placeholder pages that had almost nothing for search engines or AI assistants to cite.