### PR TITLE
feat: super-admin dashboard — live online users + MRR/growth panel

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -264,6 +264,9 @@ const supportRoutes = require('./routes/support');
 app.use('/api/admin', adminEmailLogsRoutes);
 app.use('/api/support', supportRoutes);
 
+const adminDashboardRoutes = require('./routes/adminDashboard');
+app.use('/api/admin', adminDashboardRoutes);
+
 const notFoundLogsRoutes = require('./routes/notFoundLogs');
 app.use('/api/not-found-logs', notFoundLogsRoutes);   // POST public (log 404)
 app.use('/api/admin', notFoundLogsRoutes);             // GET/PATCH/DELETE super-admin

--- a/backend/lib/wsServer.js
+++ b/backend/lib/wsServer.js
@@ -216,4 +216,8 @@ function broadcastToParticipants(participantUserIds, data) {
   }
 }
 
-module.exports = { init, broadcastSignature, broadcastMessage, broadcastToParticipants, sendToUser };
+function getOnlineUserIds() {
+  return [...onlineUsers];
+}
+
+module.exports = { init, broadcastSignature, broadcastMessage, broadcastToParticipants, sendToUser, getOnlineUserIds };

--- a/backend/routes/adminDashboard.js
+++ b/backend/routes/adminDashboard.js
@@ -1,0 +1,98 @@
+const express = require('express');
+const router = express.Router();
+
+const prisma = require('../lib/prismaClient');
+const requireAuth = require('../middleware/authMiddleware');
+const { getOnlineUserIds } = require('../lib/wsServer');
+
+// Monthly price per plan, in EUR. Overridable via env for pricing changes
+// without a deploy; falls back to the prices publicly advertised on /tarifs.
+const PLAN_PRICES_EUR = {
+  essentiel: Number(process.env.PLAN_PRICE_ESSENTIEL_EUR || 29.99),
+  pro: Number(process.env.PLAN_PRICE_PRO_EUR || 59.99),
+  decouverte: 0,
+};
+
+// GET /api/admin/online-users — currently connected users (super-admin only)
+router.get('/online-users', requireAuth, async (req, res) => {
+  try {
+    if (!req.user || req.user.role !== 'super-admin') {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    const ids = getOnlineUserIds();
+    if (ids.length === 0) return res.json({ users: [] });
+    const users = await prisma.user.findMany({
+      where: { id: { in: ids } },
+      select: { id: true, name: true, role: true, centerId: true, center: { select: { name: true } } },
+    });
+    res.json({
+      users: users.map(u => ({ id: u.id, name: u.name, role: u.role, centerName: u.center?.name || null })),
+    });
+  } catch (e) {
+    console.error('GET /api/admin/online-users error', e);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+});
+
+// GET /api/admin/revenue-stats — MRR + monthly new/canceled subscriptions (super-admin only)
+router.get('/revenue-stats', requireAuth, async (req, res) => {
+  try {
+    if (!req.user || req.user.role !== 'super-admin') {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+
+    const monthsBack = Math.min(24, Math.max(1, Number(req.query.months) || 12));
+    const now = new Date();
+    const monthStarts = [];
+    for (let i = monthsBack - 1; i >= 0; i--) {
+      monthStarts.push(new Date(now.getFullYear(), now.getMonth() - i, 1));
+    }
+
+    const subs = await prisma.subscription.findMany({
+      select: { plan: true, status: true, createdAt: true, canceledAt: true },
+    });
+
+    function mrrAt(pointInTime) {
+      let total = 0;
+      for (const s of subs) {
+        const created = new Date(s.createdAt);
+        const canceled = s.canceledAt ? new Date(s.canceledAt) : null;
+        const wasActive = created <= pointInTime && (!canceled || canceled > pointInTime);
+        if (wasActive && (s.status === 'active' || s.status === 'trialing')) {
+          total += PLAN_PRICES_EUR[s.plan] || 0;
+        }
+      }
+      return Math.round(total * 100) / 100;
+    }
+
+    const series = monthStarts.map((start, i) => {
+      const end = i + 1 < monthStarts.length ? monthStarts[i + 1] : new Date(now.getFullYear(), now.getMonth() + 1, 1);
+      const newCount = subs.filter(s => new Date(s.createdAt) >= start && new Date(s.createdAt) < end).length;
+      const canceledCount = subs.filter(s => s.canceledAt && new Date(s.canceledAt) >= start && new Date(s.canceledAt) < end).length;
+      return {
+        month: `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, '0')}`,
+        mrr: mrrAt(new Date(end.getTime() - 1)),
+        newSubscriptions: newCount,
+        canceledSubscriptions: canceledCount,
+      };
+    });
+
+    const currentMrr = series[series.length - 1]?.mrr || 0;
+    const previousMrr = series[series.length - 2]?.mrr ?? 0;
+    const mrrGrowthPct = previousMrr > 0
+      ? Math.round(((currentMrr - previousMrr) / previousMrr) * 1000) / 10
+      : (currentMrr > 0 ? 100 : 0);
+
+    res.json({
+      currentMrr,
+      previousMrr,
+      mrrGrowthPct,
+      series,
+    });
+  } catch (e) {
+    console.error('GET /api/admin/revenue-stats error', e);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+});
+
+module.exports = router;

--- a/components/ProtectedLayout.tsx
+++ b/components/ProtectedLayout.tsx
@@ -9,6 +9,7 @@ import TutorialOverlay from './TutorialOverlay';
 import TutorialMenu from './TutorialMenu';
 import { useAuth } from '../src/context/AuthContext';
 import AnnouncementBanner from './AnnouncementBanner';
+import { usePresenceWS } from '../src/hooks/usePresenceWS';
 
 export default function ProtectedLayout() {
   const { user, setUser } = useAuth();
@@ -21,6 +22,7 @@ export default function ProtectedLayout() {
 
   const { birthdays } = useBirthdayCheck(user ? centerId : undefined);
   const [showBirthday, setShowBirthday] = useState(false);
+  usePresenceWS(user?.id);
 
   useEffect(() => {
     if (!birthdays || birthdays.length === 0 || !centerId) return;

--- a/components/SuperAdminDashboardSection.tsx
+++ b/components/SuperAdminDashboardSection.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useState } from 'react';
+import { HiOutlineUsers, HiOutlineTrendingUp, HiOutlineTrendingDown } from 'react-icons/hi';
+import { fetchWithRefresh } from '../utils/fetchWithRefresh';
+import { useI18n } from '../src/lib/useI18n';
+
+const API_URL = import.meta.env.VITE_API_URL;
+
+type OnlineUser = { id: string; name: string; role: string; centerName: string | null };
+
+type RevenueMonth = { month: string; mrr: number; newSubscriptions: number; canceledSubscriptions: number };
+
+type RevenueStats = {
+  currentMrr: number;
+  previousMrr: number;
+  mrrGrowthPct: number;
+  series: RevenueMonth[];
+};
+
+const ROLE_LABEL: Record<string, string> = {
+  'super-admin': 'Super admin',
+  admin: 'Admin',
+  nanny: 'Nounou',
+  parent: 'Parent',
+};
+
+const ROLE_DOT: Record<string, string> = {
+  'super-admin': 'bg-violet-400',
+  admin: 'bg-[#1a8fa8]',
+  nanny: 'bg-amber-400',
+  parent: 'bg-emerald-400',
+};
+
+function formatEuros(n: number) {
+  return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR', maximumFractionDigits: 0 }).format(n);
+}
+
+function formatMonthLabel(month: string) {
+  const [y, m] = month.split('-').map(Number);
+  return new Date(y, m - 1, 1).toLocaleDateString('fr-FR', { month: 'short' });
+}
+
+export default function SuperAdminDashboardSection() {
+  const { t } = useI18n();
+  const [onlineUsers, setOnlineUsers] = useState<OnlineUser[]>([]);
+  const [revenue, setRevenue] = useState<RevenueStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        setError(null);
+        const [onlineRes, revenueRes] = await Promise.all([
+          fetchWithRefresh(`${API_URL}/admin/online-users`, { credentials: 'include' }),
+          fetchWithRefresh(`${API_URL}/admin/revenue-stats?months=12`, { credentials: 'include' }),
+        ]);
+        if (!onlineRes.ok || !revenueRes.ok) throw new Error('failed');
+        const onlineData = await onlineRes.json();
+        const revenueData = await revenueRes.json();
+        if (cancelled) return;
+        setOnlineUsers(onlineData.users || []);
+        setRevenue(revenueData);
+      } catch {
+        if (!cancelled) setError(t('settings.superadmin.load_error', 'Impossible de charger le tableau de bord.'));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    const interval = setInterval(load, 30000);
+    return () => { cancelled = true; clearInterval(interval); };
+  }, [t]);
+
+  if (loading && !revenue) {
+    return (
+      <div className="bg-white rounded-2xl shadow-sm p-12 text-center text-gray-400">
+        <div className="w-8 h-8 mx-auto mb-3 rounded-full border-2 border-gray-200 border-t-[#0b5566] animate-spin" />
+        <p className="text-sm font-medium">{t('settings.superadmin.loading', 'Chargement…')}</p>
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <div className="bg-white rounded-2xl shadow-sm p-6 text-sm text-red-500 font-medium">{error}</div>
+    );
+  }
+
+  const growth = revenue?.mrrGrowthPct ?? 0;
+  const growthPositive = growth >= 0;
+  const maxMrr = Math.max(1, ...(revenue?.series.map(s => s.mrr) || [1]));
+  const lastMonth = revenue?.series[revenue.series.length - 1];
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-5 gap-4">
+      {/* ── Utilisateurs connectés ── */}
+      <div className="lg:col-span-2 bg-white rounded-2xl shadow-sm overflow-hidden">
+        <div className="px-5 pt-5 pb-4 flex items-center justify-between border-b border-gray-50">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0" style={{ background: 'linear-gradient(135deg,#0b5566,#1a8fa8)' }}>
+              <HiOutlineUsers className="w-5 h-5 text-white" />
+            </div>
+            <div>
+              <div className="font-bold text-gray-900 text-sm">{t('settings.superadmin.online_users', 'Connectés en ce moment')}</div>
+              <div className="flex items-center gap-1.5 text-xs text-gray-400">
+                <span className="relative flex h-2 w-2">
+                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
+                  <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
+                </span>
+                {t('settings.superadmin.live', 'En direct')}
+              </div>
+            </div>
+          </div>
+          <span className="text-2xl font-extrabold text-gray-900">{onlineUsers.length}</span>
+        </div>
+
+        {onlineUsers.length === 0 ? (
+          <div className="px-5 py-8 text-center text-sm text-gray-400">{t('settings.superadmin.no_one_online', "Personne n'est connecté actuellement.")}</div>
+        ) : (
+          <div className="max-h-72 overflow-y-auto divide-y divide-gray-50">
+            {onlineUsers.map(u => (
+              <div key={u.id} className="flex items-center justify-between px-5 py-3">
+                <div className="flex items-center gap-2.5 min-w-0">
+                  <span className={`w-2 h-2 rounded-full flex-shrink-0 ${ROLE_DOT[u.role] || 'bg-gray-300'}`} />
+                  <div className="min-w-0">
+                    <div className="text-sm font-medium text-gray-800 truncate">{u.name}</div>
+                    {u.centerName && <div className="text-xs text-gray-400 truncate">{u.centerName}</div>}
+                  </div>
+                </div>
+                <span className="text-[11px] font-semibold text-gray-500 bg-gray-50 px-2 py-1 rounded-lg flex-shrink-0">
+                  {ROLE_LABEL[u.role] || u.role}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* ── Revenus & croissance ── */}
+      <div className="lg:col-span-3 bg-white rounded-2xl shadow-sm p-5">
+        <div className="flex items-start justify-between mb-6">
+          <div>
+            <div className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-1">{t('settings.superadmin.mrr', 'Revenu mensuel récurrent')}</div>
+            <div className="text-3xl font-extrabold text-gray-900">{formatEuros(revenue?.currentMrr || 0)}</div>
+          </div>
+          <div className={`flex items-center gap-1 text-sm font-bold px-3 py-1.5 rounded-xl ${growthPositive ? 'bg-emerald-50 text-emerald-600' : 'bg-red-50 text-red-500'}`}>
+            {growthPositive ? <HiOutlineTrendingUp className="w-4 h-4" /> : <HiOutlineTrendingDown className="w-4 h-4" />}
+            {growthPositive ? '+' : ''}{growth}%
+          </div>
+        </div>
+
+        {revenue && revenue.series.length > 0 && (
+          <div className="flex items-end gap-1.5 h-28 mb-1">
+            {revenue.series.map(s => (
+              <div key={s.month} className="flex-1 h-full flex flex-col justify-end items-center gap-1.5 group">
+                <div className="relative w-full flex justify-center">
+                  <div
+                    className="w-full max-w-[22px] rounded-t-md transition-all group-hover:opacity-80"
+                    style={{ height: `${Math.max(3, (s.mrr / maxMrr) * 100)}px`, background: 'linear-gradient(180deg,#1a8fa8,#0b5566)' }}
+                    title={`${formatMonthLabel(s.month)} : ${formatEuros(s.mrr)}`}
+                  />
+                </div>
+                <span className="text-[10px] text-gray-400 font-medium">{formatMonthLabel(s.month)}</span>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="grid grid-cols-2 gap-3 mt-5 pt-5 border-t border-gray-50">
+          <div className="bg-emerald-50/60 rounded-xl p-3">
+            <div className="text-[11px] font-semibold text-emerald-700/70 uppercase tracking-wide">{t('settings.superadmin.new_this_month', 'Nouveaux ce mois')}</div>
+            <div className="text-xl font-extrabold text-emerald-600">+{lastMonth?.newSubscriptions ?? 0}</div>
+          </div>
+          <div className="bg-red-50/60 rounded-xl p-3">
+            <div className="text-[11px] font-semibold text-red-700/60 uppercase tracking-wide">{t('settings.superadmin.canceled_this_month', 'Résiliés ce mois')}</div>
+            <div className="text-xl font-extrabold text-red-500">-{lastMonth?.canceledSubscriptions ?? 0}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/pages/Settings.tsx
+++ b/pages/Settings.tsx
@@ -12,6 +12,7 @@ import type { Theme } from '../hooks/useTheme';
 import LanguageDropdown from '../components/LanguageDropdown';
 import AvatarCropper from '../components/AvatarCropper';
 import ImportModal from '../components/ImportModal';
+import SuperAdminDashboardSection from '../components/SuperAdminDashboardSection';
 import { HiOutlineChat, HiOutlinePaperAirplane, HiOutlineClock, HiOutlineCheckCircle } from 'react-icons/hi';
 
 const API_URL = import.meta.env.VITE_API_URL;
@@ -1068,6 +1069,22 @@ export default function Settings() {
               </button>
             )}
 
+            {/* Tableau de bord — super-admin only */}
+            {isSuperAdmin && (
+              <button
+                onClick={() => setSearchParams({ section: 'dashboard' })}
+                className="bg-card rounded-2xl shadow p-4 flex flex-col gap-3 text-left hover:shadow-md hover:border-[#0b5566] border border-transparent transition group"
+              >
+                <div className="w-11 h-11 rounded-xl flex items-center justify-center text-white flex-shrink-0" style={{ background: 'linear-gradient(135deg,#0b5566,#1a8fa8)' }}>
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" /></svg>
+                </div>
+                <div>
+                  <div className="font-semibold text-primary text-sm">{t('settings.section.dashboard', 'Tableau de bord')}</div>
+                  <div className="text-xs text-muted mt-0.5">{t('settings.section.dashboard.subtitle', 'Connexions et revenus')}</div>
+                </div>
+              </button>
+            )}
+
             {/* Langue */}
             <button
               onClick={() => setSearchParams({ section: 'langue' })}
@@ -1348,6 +1365,14 @@ export default function Settings() {
                 <><svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>{t('settings.billing.save_btn')}</>
               )}
             </button>
+          </div>
+        )}
+
+        {/* ── Section: Tableau de bord (super-admin) ── */}
+        {activeSection === 'dashboard' && isSuperAdmin && (
+          <div>
+            <SectionHeader title={t('settings.section.dashboard', 'Tableau de bord')} />
+            <SuperAdminDashboardSection />
           </div>
         )}
 

--- a/src/hooks/usePresenceWS.ts
+++ b/src/hooks/usePresenceWS.ts
@@ -1,0 +1,46 @@
+import { useEffect } from 'react';
+
+/**
+ * Keeps a lightweight WebSocket connection open for the lifetime of the
+ * authenticated session so the backend's online-presence tracking
+ * (wsServer.js onlineUsers) reflects the whole app, not just the
+ * Messaging page. Mount once, high in the authenticated tree.
+ */
+export function usePresenceWS(userId: string | null | undefined) {
+  useEffect(() => {
+    if (!userId) return;
+
+    const apiUrl: string = import.meta.env.VITE_API_URL || '';
+    const wsBase = apiUrl
+      .replace(/^https:/, 'wss:')
+      .replace(/^http:/, 'ws:')
+      .replace(/\/api\/?$/, '');
+    const url = `${wsBase}/ws`;
+
+    let ws: WebSocket;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let unmounted = false;
+
+    function connect() {
+      ws = new WebSocket(url);
+      ws.onopen = () => {
+        ws.send(JSON.stringify({ type: 'auth', userId }));
+      };
+      ws.onclose = () => {
+        if (unmounted) return;
+        reconnectTimer = setTimeout(connect, 3000);
+      };
+      ws.onerror = () => {
+        ws.close();
+      };
+    }
+
+    connect();
+
+    return () => {
+      unmounted = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      ws?.close();
+    };
+  }, [userId]);
+}


### PR DESCRIPTION
Adds a new "Tableau de bord" section in Settings, visible only to super-admin accounts, showing:
- Currently connected users in real time (name, role, center).
- MRR (monthly recurring revenue), % growth vs previous month, a 12-month bar chart, and new/canceled subscriptions for the current month.

Backend:
- New routes/adminDashboard.js: GET /api/admin/online-users and GET /api/admin/revenue-stats, both gated on req.user.role === 'super-admin'. Mounted in index.js after the existing /api/admin routers to avoid any path collision with adminEmailLogs.js.
- wsServer.js now exports getOnlineUserIds() so the online-users route can read the existing presence Set instead of re-implementing it.
- MRR is computed from Subscription.plan/status/createdAt/canceledAt using per-plan prices (env-overridable, defaulting to the prices advertised on /tarifs) — no extra Stripe calls needed per request.

Frontend:
- Presence tracking previously only activated on the Messaging page (useMessagingWS's `auth` handshake), so most connected users were invisible to this new panel. Added a minimal usePresenceWS hook, mounted in ProtectedLayout (present on every authenticated route), which opens the same WebSocket and sends the `auth` handshake without touching the messaging-specific logic.
- SuperAdminDashboardSection.tsx: polls both endpoints every 30s, matches the existing AdminCenters visual language (white cards, rounded-2xl, brand gradient icons, gray-50 stat tiles) rather than introducing new design tokens.