### PR TITLE
fix: declare missing stripe and ioredis dependencies in backend

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -21,6 +21,7 @@
         "express": "^5.2.1",
         "express-rate-limit": "^7.0.0",
         "helmet": "^7.0.0",
+        "ioredis": "^6.0.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
         "node-cron": "^4.6.0",
@@ -28,6 +29,7 @@
         "nodemailer": "^9.0.4",
         "pdfkit": "^0.13.0",
         "sharp": "^0.35.3",
+        "stripe": "^18.5.0",
         "web-push": "^3.6.7",
         "ws": "^8.20.0",
         "xlsx": "^0.18.5"
@@ -549,6 +551,12 @@
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-2.0.0.tgz",
+      "integrity": "sha512-vrx0AE/T0h7cRZwfo1M39Cr+ZhZrkf0V8mQN75wucKCxCLD9l/VX6no3gFvrLqD1IlG/1LtzWovqEw3t0Vr9zg==",
+      "license": "MIT"
     },
     "node_modules/@prisma/client": {
       "version": "6.16.1",
@@ -1185,6 +1193,15 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
+      "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/codepage": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
@@ -1468,6 +1485,15 @@
       "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -2073,6 +2099,27 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ioredis": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-6.0.0.tgz",
+      "integrity": "sha512-f+Dtubxfpf6KYFq7WVXJoOLn0bk4TJrMrN9SzeE+jrWrCWj7XX3fA6vkryafhADX+GMymRxgDJDOI33COkJc0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "2.0.0",
+        "cluster-key-slot": "1.1.1",
+        "debug": "4.4.3",
+        "denque": "2.1.0",
+        "redis-errors": "1.2.0",
+        "standard-as-callback": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
       }
     },
     "node_modules/ipaddr.js": {
@@ -3043,6 +3090,15 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -3358,6 +3414,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -3395,6 +3457,26 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "18.5.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-18.5.0.tgz",
+      "integrity": "sha512-Hp+wFiEQtCB0LlNgcFh5uVyKznpDjzyUZ+CNVEf+I3fhlYvh7rZruIg+jOwzJRCpy0ZTPMjlzm7J2/M2N6d+DA==",
+      "license": "MIT",
+      "dependencies": {
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      },
+      "peerDependencies": {
+        "@types/node": ">=12.x.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/tailwindcss": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
     "express": "^5.2.1",
     "express-rate-limit": "^7.0.0",
     "helmet": "^7.0.0",
+    "ioredis": "^6.0.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
     "node-cron": "^4.6.0",
@@ -33,6 +34,7 @@
     "nodemailer": "^9.0.4",
     "pdfkit": "^0.13.0",
     "sharp": "^0.35.3",
+    "stripe": "^18.5.0",
     "web-push": "^3.6.7",
     "ws": "^8.20.0",
     "xlsx": "^0.18.5"


### PR DESCRIPTION
routes/subscriptions.js, routes/paymentInvoice.js (require('stripe')) and lib/redisCache.js (require('ioredis')) were never listed in backend/package.json — grepped the entire history and confirmed `stripe` has never been declared there. Whatever install previously put a stripe package on disk (manually, or copied from elsewhere) was never tracked, so the backend only worked by accident until node_modules got reinstalled without it.

Symptom: index.js requires every route file at boot, including subscriptions.js, so a missing `stripe` module crashed the entire backend process at startup (MODULE_NOT_FOUND). Every request — login included — failed as a result; the frontend's generic error fallback then displayed a misleading "Identifiants invalides" instead of the real 500/crash.